### PR TITLE
Fix best products image

### DIFF
--- a/dashproducts.php
+++ b/dashproducts.php
@@ -226,7 +226,7 @@ class dashproducts extends Module
             if (($row_image = Product::getCover($product_obj->id)) && $row_image['id_image']) {
                 $image = new Image($row_image['id_image']);
                 $path_to_image = _PS_PROD_IMG_DIR_.$image->getExistingImgPath().'.'.$this->context->controller->imageType;
-                $img = ImageManager::thumbnail($path_to_image, 'product_mini_'.$product_obj->id.'.'.$this->context->controller->imageType, 45, $this->context->controller->imageType);
+                $img = ImageManager::thumbnail($path_to_image, 'product_mini_'.$row_image['id_image'].'.'.$this->context->controller->imageType, 45, $this->context->controller->imageType);
             }
 
             $productPrice = $product['price'];


### PR DESCRIPTION
Images displayed where using product id as part of their names, instead of image id.