### PR TITLE
[Blocked] Migrate dashproducts widget to new dashboard

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@ GitHub contributors:
  - mickaelandrieu
  - tchauviere
  - xBorderie
+ - ks129

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,13 @@
       "email": "contact@prestashop.com"
     }
   ],
+  "autoload": {
+    "psr-4": {
+      "PrestaShop\\Module\\Dashproducts\\": "src/"
+    }
+  },
   "require": {
-    "php": ">=5.4"
+    "php": ">=7.1"
   },
   "config": {
     "preferred-install": "dist"

--- a/config/index.php
+++ b/config/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/config/services.yml
+++ b/config/services.yml
@@ -1,0 +1,29 @@
+services:
+  _defaults:
+    public: true
+
+  prestashop.module.dashproducts.form.type.dashproducts_configuration:
+    class: 'PrestaShop\Module\Dashproducts\Form\DashproductsConfigurationType'
+    parent: 'form.type.translatable.aware'
+    public: true
+    tags:
+      - { name: form.type }
+
+  prestashop.module.dashproducts.form.dashproducts_configuration_data_configuration:
+    class: 'PrestaShop\Module\Dashproducts\Form\DashproductsConfigurationDataConfiguration'
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+
+  prestashop.module.dashproducts.form.dashproducts_configuration_form_data_provider:
+    class: 'PrestaShop\Module\Dashproducts\Form\DashproductsConfigurationFormDataProvider'
+    arguments:
+      - '@prestashop.module.dashproducts.form.dashproducts_configuration_data_configuration'
+
+  prestashop.module.dashproducts.form.dashproducts_configuration_form_data_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.module.dashproducts.form.dashproducts_configuration_form_data_provider'
+      - 'PrestaShop\Module\Dashproducts\Form\DashproductsConfigurationType'
+      - 'DashproductsConfiguration'

--- a/dashproducts.php
+++ b/dashproducts.php
@@ -46,7 +46,7 @@ class dashproducts extends Module
         parent::__construct();
         $this->displayName = $this->trans('Dashboard Products', array(), 'Modules.Dashproducts.Admin');
         $this->description = $this->trans('Enrich your stats, display a table of your latest orders and a ranking of your products.', array(), 'Modules.Dashproducts.Admin');
-        $this->ps_versions_compliancy = array('min' => '1.7.1.0', 'max' => _PS_VERSION_);
+        $this->ps_versions_compliancy = array('min' => '1.7.7.0', 'max' => _PS_VERSION_);
     }
 
     public function install()

--- a/src/Form/DashproductsConfigurationDataConfiguration.php
+++ b/src/Form/DashproductsConfigurationDataConfiguration.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Dashproducts\Form;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+
+/**
+ * Handles configuration data for dashproducts module configuration.
+ */
+final class DashproductsConfigurationDataConfiguration implements DataConfigurationInterface
+{
+    private const ALLOWED_VALUES = [5, 10, 20, 50];
+
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(ConfigurationInterface $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration(): array
+    {
+        return [
+            'show_last_order' => (int) $this->configuration->get('DASHPRODUCT_NBR_SHOW_LAST_ORDER'),
+            'show_best_seller' => (int) $this->configuration->get('DASHPRODUCT_NBR_SHOW_BEST_SELLER'),
+            'show_most_viewed' => (int) $this->configuration->get('DASHPRODUCT_NBR_SHOW_MOST_VIEWED'),
+            'show_top_searches' => (int) $this->configuration->get('DASHPRODUCT_NBR_SHOW_TOP_SEARCH'),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration): array
+    {
+        if ($this->validateConfiguration($configuration)) {
+            $this->configuration->set('DASHPRODUCT_NBR_SHOW_LAST_ORDER', (int) $configuration['show_last_order']);
+            $this->configuration->set('DASHPRODUCT_NBR_SHOW_BEST_SELLER', (int) $configuration['show_best_seller']);
+            $this->configuration->set('DASHPRODUCT_NBR_SHOW_MOST_VIEWED', (int) $configuration['show_most_viewed']);
+            $this->configuration->set('DASHPRODUCT_NBR_SHOW_TOP_SEARCH', (int) $configuration['show_top_searches']);
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateConfiguration(array $configuration): bool
+    {
+        return (
+            // Last orders
+            isset($configuration['show_last_order'])
+            && is_numeric($configuration['show_last_order'])
+            && in_array((int) $configuration['show_last_order'], self::ALLOWED_VALUES)
+            // Best sellers
+            && isset($configuration['show_best_seller'])
+            && is_numeric($configuration['show_best_seller'])
+            && in_array((int) $configuration['show_last_order'], self::ALLOWED_VALUES)
+            // Most viewed
+            && isset($configuration['show_most_viewed'])
+            && is_numeric($configuration['show_most_viewed'])
+            && in_array((int) $configuration['show_last_order'], self::ALLOWED_VALUES)
+            // Top searches
+            && isset($configuration['show_top_searches'])
+            && is_numeric($configuration['show_top_searches'])
+            && in_array((int) $configuration['show_last_order'], self::ALLOWED_VALUES)
+        );
+    }
+}

--- a/src/Form/DashproductsConfigurationFormDataProvider.php
+++ b/src/Form/DashproductsConfigurationFormDataProvider.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Dashproducts\Form;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+/**
+ * Handles dashproducts configuration for data fetching and setting.
+ */
+class DashproductsConfigurationFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * @var DataConfigurationInterface
+     */
+    private $dashproductsConfigurationDataProvider;
+
+    /**
+     * @param DataConfigurationInterface $dashproductsConfigurationDataProvider
+     */
+    public function __construct(DataConfigurationInterface $dashproductsConfigurationDataProvider)
+    {
+        $this->dashproductsConfigurationDataProvider = $dashproductsConfigurationDataProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(): array
+    {
+        return $this->dashproductsConfigurationDataProvider->getConfiguration();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setData(array $data): array
+    {
+        return $this->dashproductsConfigurationDataProvider->updateConfiguration($data);
+    }
+}

--- a/src/Form/DashproductsConfigurationType.php
+++ b/src/Form/DashproductsConfigurationType.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Dashproducts\Form;
+
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Defines dashproducts configuration form.
+ */
+class DashproductsConfigurationType extends TranslatorAwareType
+{
+    private const CHOICES = [
+        5 => 5,
+        10 => 10,
+        20 => 20,
+        50 => 50,
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('show_last_order', ChoiceType::class, [
+                'label' => $this->trans('Number of "Recent Orders" to display', 'Modules.Dashproducts.Admin'),
+                'choices' => self::CHOICES,
+                'required' => false,
+                'placeholder' => false,
+            ])
+            ->add('show_best_seller', ChoiceType::class, [
+                'label' => $this->trans('Number of "Best Sellers" to display', 'Modules.Dashproducts.Admin'),
+                'choices' => self::CHOICES,
+                'required' => false,
+                'placeholder' => false,
+            ])
+            ->add('show_most_viewed', ChoiceType::class, [
+                'label' => $this->trans('Number of "Most Viewed" to display', 'Modules.Dashproducts.Admin'),
+                'choices' => self::CHOICES,
+                'required' => false,
+                'placeholder' => false,
+            ])
+            ->add('show_top_searches', ChoiceType::class, [
+                'label' => $this->trans('Number of "Top Searches" to display', 'Modules.Dashproducts.Admin'),
+                'choices' => self::CHOICES,
+                'required' => false,
+                'placeholder' => false,
+            ]);
+    }
+}

--- a/src/Form/index.php
+++ b/src/Form/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/index.php
+++ b/src/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/views/dashboard_zone_two.html.twig
+++ b/views/dashboard_zone_two.html.twig
@@ -61,7 +61,7 @@
                         </div>
 
                         <div class="card-footer">
-                        	<div class="d-flex justify-content-end">
+                            <div class="d-flex justify-content-end">
                         	    <button class="btn btn-primary submit_dash_config float-right">
                         	        {{ 'Save'|trans({}, 'Admin.Actions') }}
                         	    </button>

--- a/views/dashboard_zone_two.html.twig
+++ b/views/dashboard_zone_two.html.twig
@@ -19,7 +19,7 @@
 
 {% trans_default_domain 'Modules.Dashproducts.Admin' %}
 
-<section id="dashproducts" class="card">
+<section id="dashproducts" class="card widget allow_push">
     <div class="card-header">
         <div class="d-flex">
             <div class="mr-auto">

--- a/views/dashboard_zone_two.html.twig
+++ b/views/dashboard_zone_two.html.twig
@@ -1,0 +1,212 @@
+{#**
+* Copyright since 2007 PrestaShop SA and Contributors
+* PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License version 3.0
+* that is bundled with this package in the file LICENSE.md.
+* It is also available through the world-wide-web at this URL:
+* https://opensource.org/licenses/AFL-3.0
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* @author    PrestaShop SA and Contributors <contact@prestashop.com>
+* @copyright Since 2007 PrestaShop SA and Contributors
+* @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+*#}
+
+{% trans_default_domain 'Modules.Dashproducts.Admin' %}
+
+<section id="dashproducts" class="card">
+    <div class="card-header">
+        <div class="d-flex">
+            <div class="mr-auto">
+                <i class="material-icons">insert_chart_outlined</i>
+                {{ 'Products and Sales'|trans }}
+            </div>
+            <div>
+                {% if dashproductsConfigForm is not null %}
+                    <a href="#"
+                       title="{{ 'Configure'|trans({}, 'Admin.Actions') }}"
+                       onclick="return false;"
+                       class="text-decoration-none dash-config-btn"
+                    >
+                        <i class="material-icons">settings</i>
+                    </a>
+                {% endif %}
+                <a href="#"
+                   title="{{ 'Refresh'|trans({}, 'Admin.Actions') }}"
+                   class="text-decoration-none dash-refresh"
+                >
+                    <i class="material-icons">refresh</i>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <div class="card-body">
+        {% if dashproductsConfigForm is not null %}
+            {{ form_start(dashproductsConfigForm) }}
+                <section id="dashproducts_config" class="dash_config d-none">
+                    <div class="card">
+                        <div class="card-header">
+                            <i class="material-icons">build</i>
+                            {{ 'Configuration'|trans({}, 'Admin.Global') }}
+                        </div>
+
+                        <div class="card-body">
+                            {{ form_widget(dashproductsConfigForm) }}
+                        </div>
+
+                        <div class="card-footer">
+                        	<div class="d-flex justify-content-end">
+                        	    <button class="btn btn-primary submit_dash_config float-right">
+                        	        {{ 'Save'|trans({}, 'Admin.Actions') }}
+                        	    </button>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            {{ form_end(dashproductsConfigForm) }}
+        {% endif %}
+
+        <section>
+            <ul class="nav nav-tabs" role="tablist">
+                <li class="nav-item">
+                    <a class="nav-link active"
+                       href="#dash-recent-orders"
+                       id="dash-recent-orders-tab"
+                       data-toggle="pill"
+                       role="tab"
+                       aria-controls="dash_recent_orders"
+                       aria-expanded="true"
+                    >
+                        <i class="material-icons">local_fire_department</i>
+                        {{ 'Recent Orders'|trans }}
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link"
+                       href="#dash-best-seller"
+                       id="dash-best-seller-tab"
+                       data-toggle="pill"
+                       role="tab"
+                       aria-controls="dash_best_seller"
+                       aria-expanded="true"
+                    >
+                        <i class="material-icons">emoji_events</i>
+                        {{ 'Best Sellers'|trans }}
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link"
+                       href="#dash-most-viewed"
+                       id="dash-most-viewed-tab"
+                       data-toggle="pill"
+                       role="tab"
+                       aria-controls="dash_most_viewed"
+                       aria-expanded="true"
+                    >
+                        <i class="material-icons">visibility</i>
+                        {{ 'Most Viewed'|trans }}
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link"
+                       href="#dash-top-searches"
+                       id="dash-top-searches-tab"
+                       data-toggle="pill"
+                       role="tab"
+                       aria-controls="dash_top_searches"
+                       aria-expanded="true"
+                    >
+                        <i class="material-icons">search</i>
+                        {{ 'Top Searches'|trans }}
+                    </a>
+                </li>
+            </ul>
+
+            <div class="tab-content">
+                <div class="tab-pane fade show active"
+                     id="dash-recent-orders"
+                     role="tabpanel"
+                     aria-labelledby="dash-recent-orders-tab"
+                >
+                    <div class="card">
+                        <div class="card-header">
+                            {{ 'Last %showLast% orders'|trans({'%showLast%': DASHPRODUCT_NBR_SHOW_LAST_ORDER|number_format}) }}
+                        </div>
+
+                        <div class="card-body">
+                            <table class="table data_table" id="table_recent_orders">
+                                <thead></thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="tab-pane fade show"
+                     id="dash-best-seller"
+                     role="tabpanel"
+                     aria-labelledby="dash-best-seller-tab"
+                >
+                    <div class="card">
+                        <div class="card-header">
+                            {{ 'Top %showTop% products'|trans({'%showTop%': DASHPRODUCT_NBR_SHOW_BEST_SELLER|number_format}) }}
+                        </div>
+
+                        <div class="card-body">
+                            <table class="table data_table" id="table_best_sellers">
+                                <thead></thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="tab-pane fade show"
+                     id="dash-most-viewed"
+                     role="tabpanel"
+                     aria-labelledby="dash-most-viewed-tab"
+                >
+                    <div class="card">
+                        <div class="card-header">
+                            {{ 'Most viewed'|trans }}
+                            <span>{{ 'From'|trans }} {{ dateFrom|escape }} {{ 'to'|trans }} {{ dateTo|escape }}</span>
+                        </div>
+
+                        <div class="card-body">
+                            <table class="table data_table" id="table_most_viewed">
+                                <thead></thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="tab-pane fade show"
+                     id="dash-top-searches"
+                     role="tabpanel"
+                     aria-labelledby="dash-top-searches-tab"
+                >
+                    <div class="card">
+                        <div class="card-header">
+                            {{ 'Top %showMost% most search terms'|trans({'%showMost%': DASHPRODUCT_NBR_SHOW_TOP_SEARCH|number_format}) }}
+                            <span>{{ 'From'|trans }} {{ dateFrom|escape }} {{ 'to'|trans }} {{ dateTo|escape }}</span>
+                        </div>
+
+                        <div class="card-body">
+                            <table class="table data_table" id="table_top_10_most_search">
+                                <thead></thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+</section>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This migration is part of dashboard migration. This has 2 BC breaks, a PHP version bump from 5.4 to 7.1, and a PS version requirement bump from 1.7.1 to 1.7.7. QA has to make sure this module keeps working with the old system and also works with the new system.
| Type?         | refacto
| BC breaks?    | yes
| Deprecations? | no (not sure)
| Fixed ticket? | Part of PrestaShop/Prestashop#10185.
| How to test?  | Functionality should stay the same as this was and the module should work the same way in both dashboards.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
