### PR TITLE
Fix bad display in the Dashboard page

### DIFF
--- a/views/templates/hook/dashboard_zone_two.tpl
+++ b/views/templates/hook/dashboard_zone_two.tpl
@@ -88,10 +88,10 @@
         </div>
       </div>
       <div class="tab-pane" id="dash_best_sellers">
-        <h3>
+        <div class="panel-heading">
           {l s='Top %d products' sprintf=$DASHPRODUCT_NBR_SHOW_BEST_SELLER|intval d='Modules.Dashproducts.Admin'}
           <span>{l s="From" d='Modules.Dashproducts.Admin'} {$date_from|escape:'htmlall':'UTF-8'} {l s="to" d='Modules.Dashproducts.Admin'} {$date_to|escape:'htmlall':'UTF-8'}</span>
-        </h3>
+        </div>
         <div class="table-responsive">
           <table class="table data_table" id="table_best_sellers">
             <thead></thead>
@@ -100,10 +100,10 @@
         </div>
       </div>
       <div class="tab-pane" id="dash_most_viewed">
-        <h3>
+        <div class="panel-heading">
           {l s="Most Viewed" d='Modules.Dashproducts.Admin'}
           <span>{l s="From" d='Modules.Dashproducts.Admin'} {$date_from|escape:'htmlall':'UTF-8'} {l s="to" d='Modules.Dashproducts.Admin'} {$date_to|escape:'htmlall':'UTF-8'}</span>
-        </h3>
+        </div>
         <div class="table-responsive">
           <table class="table data_table" id="table_most_viewed">
             <thead></thead>
@@ -112,10 +112,10 @@
         </div>
       </div>
       <div class="tab-pane" id="dash_top_search">
-        <h3>
+        <div class="panel-heading">
           {l s='Top %d most search terms' sprintf=$DASHPRODUCT_NBR_SHOW_TOP_SEARCH|intval d='Modules.Dashproducts.Admin'}
           <span>{l s="From" d='Modules.Dashproducts.Admin'} {$date_from|escape:'htmlall':'UTF-8'} {l s="to" d='Modules.Dashproducts.Admin'} {$date_to|escape:'htmlall':'UTF-8'}</span>
-        </h3>
+        </div>
         <div class="table-responsive">
           <table class="table data_table" id="table_top_10_most_search">
             <thead></thead>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Bad display in the Dashboard of the module `dashproducts`
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/26231
| How to test?  | Go to Dahsbord page, and check that `Last %number of% orders` is well displayed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
**Before**
![image](https://user-images.githubusercontent.com/16067358/137111493-163099f5-21ab-4eb6-a438-a6d5de16a4db.png)
**After**
![image](https://user-images.githubusercontent.com/16067358/137111528-3f7be035-bedf-4672-a49b-efdabfae7051.png)
