### PR TITLE
Remove code related to live update (`push`)

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>dashproducts</name>
 	<displayName><![CDATA[Dashboard Products]]></displayName>
-	<version><![CDATA[2.1.1]]></version>
+	<version><![CDATA[2.1.2]]></version>
 	<description><![CDATA[Adds a block with a table of your latest orders and a ranking of your products]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[dashboard]]></tab>

--- a/dashproducts.php
+++ b/dashproducts.php
@@ -34,11 +34,8 @@ class dashproducts extends Module
     {
         $this->name = 'dashproducts';
         $this->tab = 'dashboard';
-        $this->version = '2.1.1';
+        $this->version = '2.1.2';
         $this->author = 'PrestaShop';
-
-        $this->push_filename = _PS_CACHE_DIR_.'push/activity';
-        $this->allow_push = true;
 
         parent::__construct();
         $this->displayName = $this->trans('Dashboard Products', array(), 'Modules.Dashproducts.Admin');
@@ -56,8 +53,6 @@ class dashproducts extends Module
         return (parent::install()
             && $this->registerHook('dashboardZoneTwo')
             && $this->registerHook('dashboardData')
-            && $this->registerHook('actionObjectOrderAddAfter')
-            && $this->registerHook('actionSearch')
         );
     }
 
@@ -250,7 +245,7 @@ class dashproducts extends Module
                 ),
                 array(
                     'id' => 'product',
-                    'value' => '<a href="'.$this->context->link->getAdminLink('AdminProducts', true, ['id_product' => $product_obj->id, 'updateproduct' => 1]).'">'.Tools::htmlentitiesUTF8($product['product_name']).'</a>'.'<br/>' . 
+                    'value' => '<a href="'.$this->context->link->getAdminLink('AdminProducts', true, ['id_product' => $product_obj->id, 'updateproduct' => 1]).'">'.Tools::htmlentitiesUTF8($product['product_name']).'</a>'.'<br/>' .
 			$this->context->getCurrentLocale()->formatPrice($productPrice, $this->context->currency->iso_code),
                     'class' => 'text-center'
                 ),
@@ -614,16 +609,6 @@ class dashproducts extends Module
             'DASHPRODUCT_NBR_SHOW_MOST_VIEWED' => Configuration::get('DASHPRODUCT_NBR_SHOW_MOST_VIEWED'),
             'DASHPRODUCT_NBR_SHOW_TOP_SEARCH' => Configuration::get('DASHPRODUCT_NBR_SHOW_TOP_SEARCH'),
         );
-    }
-
-    public function hookActionObjectOrderAddAfter($params)
-    {
-        Tools::changeFileMTime($this->push_filename);
-    }
-
-    public function hookActionSearch($params)
-    {
-        Tools::changeFileMTime($this->push_filename);
     }
 
     /**

--- a/upgrade/upgrade-2.1.2.php
+++ b/upgrade/upgrade-2.1.2.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_1_2($object)
+{
+    return $object->unregisterHook('actionObjectOrderAddAfter')
+        && $object->unregisterHook('actionSearch');
+}

--- a/views/templates/hook/dashboard_zone_two.tpl
+++ b/views/templates/hook/dashboard_zone_two.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 
-<section id="dashproducts" class="panel widget {if $allow_push} allow_push{/if}">
+<section id="dashproducts" class="panel widget">
   <header class="panel-heading">
     <i class="icon-bar-chart"></i> {l s='Products and Sales' d='Modules.Dashproducts.Admin'}
     <span class="panel-heading-action">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR aims to remove an unused feature (live update) that has been removed from the core but make this module throw an exception because even though the feature is not used, it requires a smarty variable not available anymore.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes PrestaShop/Prestashop#27028
| How to test?  | On PrestaShop develop:<br>1. Disable modules `Dashactivity` & `Dashtrends`<br>2. Comment the line https://github.com/PrestaShop/PrestaShop/blob/develop/classes/module/Module.php#L2185 (`'allow_push' => false, // required by dashboard modules`)<br>3. Install this module<br>4. No error should appear in the page Dashboard

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
