### PR TITLE
Fix query "BIGINT UNSIGNED value is out of range"

### DIFF
--- a/dashproducts.php
+++ b/dashproducts.php
@@ -200,7 +200,7 @@ class dashproducts extends Module
 					SELECT
 						product_id,
 						product_name,
-						SUM(product_quantity-product_quantity_refunded-product_quantity_return-product_quantity_reinjected) as total,
+						SUM(CAST(product_quantity as signed)-CAST(product_quantity_refunded as signed)-CAST(product_quantity_return as signed)-CAST(product_quantity_reinjected as signed)) as total,
 						p.price as price,
 						pa.price as price_attribute,
 						SUM(total_price_tax_excl / conversion_rate) as sales,


### PR DESCRIPTION
| Questions | Answers |
| ------ | ------ |
| Description | Fix query error with a result of a white dashboard widget and a error log PHP Warning:  Invalid argument supplied for foreach() in /modules/dashproducts/dashproducts.php on line 219 and a SQL error with message "BIGINT UNSIGNED value is out of range in '`prestashop_db`.`od`.`product_quantity` - `prestashop_db`.`od`.`product_quantity_refunded` - `prestashop_db`.`od`.`product_quantity_return` - `prestashop_db`.`od`.`product_quantity_reinjected`'". Fixed by casting the values on the SUM aggregator function 
| Type | Bugfix |
| BC breaks | No |
| Depreactions | I hope no |
| Fixed ticket | n/d |
| How to test | PS 1.7.8.2, PHP 7.4.27, 10.5.13-MariaDB, bestproducts v2.1.1 |

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
