### PR TITLE
Fix PHP Warning:  Illegal string offset 'id_category_default'

### DIFF
--- a/dashproducts.php
+++ b/dashproducts.php
@@ -221,7 +221,10 @@ class dashproducts extends Module
             if (!Validate::isLoadedObject($product_obj)) {
                 continue;
             }
-            $category = new Category($product_obj->getDefaultCategory()['id_category_default'], $this->context->language->id);
+            $default_category = $product_obj->getDefaultCategory();
+            $default_category_id = (int)(is_array($default_category) ?
+                $default_category['id_category_default'] : $default_category);
+            $category = new Category($default_category_id, $this->context->language->id);
 
             $img = '';
             if (($row_image = Product::getCover($product_obj->id)) && $row_image['id_image']) {

--- a/dashproducts.php
+++ b/dashproducts.php
@@ -222,7 +222,7 @@ class dashproducts extends Module
                 continue;
             }
             $default_category = $product_obj->getDefaultCategory();
-            $default_category_id = (int)(is_array($default_category) ?
+            $default_category_id = (int) (is_array($default_category) ?
                 $default_category['id_category_default'] : $default_category);
             $category = new Category($default_category_id, $this->context->language->id);
 

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -7,3 +7,4 @@ parameters:
     - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'
     - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, string given.#'
     - '#Parameter \#1 \$variable of method ModuleCore::getPermission\(\) expects array, string given.#'
+    - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given#'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Correctly handles the varying types of returned value from `Product->getDefaultCategory()`<br/>Because `Product->getDefaultCategory()` returns either an `array` or an `int` \(or a `false\|string` with older PrestaShop versions prior to https://github.com/PrestaShop/PrestaShop/pull/26478 's patch\), the returned value type must be tested and handled accordingly or; php will raise a `PHP Warning:  Illegal string offset 'id_category_default'`, and more problematically use the wrong default category id value.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#31747.
| How to test?  | Using PHP 7.2 or above, access to the Backoffice's Dashboard and, see no more `PHP Warning:  Illegal string offset 'id_category_default'`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
