### PR TITLE
Fallback on a previous version of constant

### DIFF
--- a/dashproducts.php
+++ b/dashproducts.php
@@ -231,7 +231,7 @@ class dashproducts extends Module
             $img = '';
             if (($row_image = Product::getCover($product_obj->id)) && $row_image['id_image']) {
                 $image = new Image((int) $row_image['id_image']);
-                $path_to_image = _PS_PROD_IMG_DIR_ . $image->getExistingImgPath() . '.' . $this->context->controller->imageType;
+                $path_to_image = (defined('_PS_PRODUCT_IMG_DIR_') ? _PS_PRODUCT_IMG_DIR_ : _PS_PROD_IMG_DIR_) . $image->getExistingImgPath() . '.' . $this->context->controller->imageType;
                 $img = ImageManager::thumbnail($path_to_image, 'product_mini_' . $row_image['id_image'] . '.' . $this->context->controller->imageType, 45, $this->context->controller->imageType);
             }
 
@@ -326,7 +326,7 @@ class dashproducts extends Module
                     $img = '';
                     if (($row_image = Product::getCover($product_obj->id)) && $row_image['id_image']) {
                         $image = new Image((int) $row_image['id_image']);
-                        $path_to_image = _PS_PROD_IMG_DIR_ . $image->getExistingImgPath() . '.' . $this->context->controller->imageType;
+                        $path_to_image = (defined('_PS_PRODUCT_IMG_DIR_') ? _PS_PRODUCT_IMG_DIR_ : _PS_PROD_IMG_DIR_) . $image->getExistingImgPath() . '.' . $this->context->controller->imageType;
                         $img = ImageManager::thumbnail(
                             $path_to_image,
                             'product_mini_' . $product_obj->id . '.' . $this->context->controller->imageType,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | _PS_PROD_IMG_DIR_ is deprecated since 1.7.8.1 in favor of _PS_PRODUCT_IMG_DIR_. If we want to remove it, we must stop using it. If we want to keep the minimal version, let's use this condition.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 