### PR TITLE
Dashboard recent orders : display "Deleted customer"

### DIFF
--- a/dashproducts.php
+++ b/dashproducts.php
@@ -119,7 +119,7 @@ class dashproducts extends Module
                     ]),
                     Tools::htmlentitiesUTF8($order['firstname']),
                     Tools::htmlentitiesUTF8($order['lastname'])
-                ) : '',
+                ) : $this->trans('Deleted customer', [], 'AdminGlobal'),
                 'class' => 'text-left',
             ];
             $tr[] = [


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | On the recent orders tab of dashboard, display "Deleted customer" instead of empty field.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#30453.
| How to test?  | 1. Create an order with a customer<br>2. Go to BO > check the table Products and Sales -  Recent orders > The order is displayed in the Recent Orders<br>3. Delete this customer<br>4. Go to BO >  Products and Sales - Recent orders > The customer field is not empty, but filled with "Deleted customer"

![image](https://github.com/PrestaShop/dashproducts/assets/13508863/e5d21e20-b443-4e22-9ac9-058c7f36d1d5)


This is my first open source PR, feel free to advise me :)
