### PR TITLE
avoid sql error with refunded product

### DIFF
--- a/dashproducts.php
+++ b/dashproducts.php
@@ -198,7 +198,7 @@ class dashproducts extends Module
 					SELECT
 						product_id,
 						product_name,
-						SUM(product_quantity-product_quantity_refunded-product_quantity_return-product_quantity_reinjected) as total,
+						SUM(product_quantity-product_quantity_refunded-product_quantity_return) as total,
 						p.price as price,
 						pa.price as price_attribute,
 						SUM(total_price_tax_excl / conversion_rate) as sales,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | There is a SQL error when there is at least a refunded product in a validated order:<br>> SQLSTATE[22003]: Numeric value out of range: 1690 BIGINT UNSIGNED value is out of range in '(((`dbs9731789`.`od`.`product_quantity` - `dbs9731789`.`od`.`product_quantity_refunded`) - `dbs9731789`.`od`.`product_quantity_return`) - `dbs9731789`.`od`.`product_quantity_reinjected`)'<br>due to the fact that columns product_quantity, product_quantity_refunded, product_quantity_return, and product_quantity_reinjected are unsigned so the sum is unsigned. But there is a refunded/return product in an order, it could be automatically reinjected. So quantity - refunded/return quantity - reinjected quantity is negative. so it gives a SQL error.
| Type?         | bug fix
| BC breaks?    |no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#35107. & PrestaShop/Prestashop#28431
| How to test?  | 1. Create a validated order (payment by credit card)<br>2. go to BO and in the order<br>3. Create a refunding<br>4. go to dashboard<br>5. see there IS data in dashproducts hook

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
