### PR TITLE
Don't ignore last day in Top 10 Most Search and most viewed products

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -74,14 +74,14 @@ jobs:
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
@@ -74,14 +74,14 @@ jobs:
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/dashproducts.php
+++ b/dashproducts.php
@@ -471,7 +471,7 @@ class dashproducts extends Module
         WHERE pt.`name` = \'product\'
         ' . Shop::addSqlRestriction(false, 'pv') . '
         AND dr.`time_start` BETWEEN "' . pSQL($date_from) . '" AND "' . pSQL($date_to) . '"
-        AND dr.`time_end` BETWEEN "' . pSQL($date_from) . '" AND "' . pSQL($date_to) . '"
+        AND dr.`time_end` BETWEEN "' . pSQL($date_from) . '" AND "' . pSQL($date_to) . ' 23:59:59"
         ORDER BY pv.counter DESC
         LIMIT ' . (int) $limit);
     }
@@ -485,7 +485,7 @@ class dashproducts extends Module
         return Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->executeS('
 		SELECT `keywords`, count(`id_statssearch`) as count_keywords, `results`
 		FROM `' . _DB_PREFIX_ . 'statssearch` ss
-		WHERE ss.`date_add` BETWEEN "' . pSQL($date_from) . '" AND "' . pSQL($date_to) . '"
+		WHERE ss.`date_add` BETWEEN "' . pSQL($date_from) . '" AND "' . pSQL($date_to) . ' 23:59:59"
 		' . Shop::addSqlRestriction(false, 'ss') . '
 		GROUP BY ss.`keywords`
 		ORDER BY `count_keywords` DESC


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>
| Questions | Answers |
|-----------|---------|
| Description? | This PR addresses an issue where the last day is ignored in the Top 10 Most Searched and Most Viewed products. The fix ensures that the data for the last day is included in the calculations. CI/CD : actions/cache@v1 and v2 replaced by v4 |
| Type? | bug fix |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Fixes [PrestaShop/Prestashop#38934](https://github.com/PrestaShop/PrestaShop/issues/38934). |
| How to test? | To verify this PR, follow these steps: <br> 1. Go to the back office and navigate to the statistics section for most searched and most viewed products. <br> 2. Check the data displayed for the Top 10 Most Searched and Most Viewed products. <br> 3. Ensure that the data includes the last day's statistics. <br> 4. Compare the results with previous data to confirm that the last day is now included. |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
