### PR TITLE
Provide absolute URL to fix routing issues

### DIFF
--- a/dashproducts.php
+++ b/dashproducts.php
@@ -148,7 +148,7 @@ class dashproducts extends Module
                 'id' => 'details',
                 'value' => '',
                 'class' => 'text-right',
-                'wrapper_start' => '<a class="btn btn-default" href="' . $this->context->link->getAdminLink('AdminOrders', true, [], ['id_order' => (int) $order['id_order'], 'vieworder' => 1]) . " title="' . $this->trans('Details', [], 'Modules.Dashproducts.Admin') . '"><i class="icon-search"></i>',
+                'wrapper_start' => '<a class="btn btn-default" href="' . $this->context->link->getAdminLink('AdminOrders', true, [], ['id_order' => (int) $order['id_order'], 'vieworder' => 1]) . '" title="' . $this->trans('Details', [], 'Modules.Dashproducts.Admin') . '"><i class="icon-search"></i>',
                 'wrapper_end' => '</a>',
             ];
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Provide absolute URL to fix routing issues. Fixes potential issues coming from relative URLs not being reliable after symfony migration. See https://github.com/PrestaShop/PrestaShop/issues/39185. cc @Touxten 
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39185
| Sponsor company   | TRENDO s.r.o.
| How to test?      | Just test the module can be configured correctly and loads in the backoffice, so we didn't break anything or have some typo. (On nginx server, this could be problematic.)
